### PR TITLE
subset bed file to bed3. add intervals_format arg

### DIFF
--- a/bpnet/premade/bpnet9-chipseq.gin
+++ b/bpnet/premade/bpnet9-chipseq.gin
@@ -93,6 +93,7 @@ bpnet_data.tasks = %tasks
 bpnet_data.exclude_chr = %exclude_chr
 bpnet_data.augment_interval = %augment_interval
 bpnet_data.interval_augmentation_shift = 200
+bpnet_data.intervals_format = 'bed'
 
 # transform the bias track by aggregating it in a
 # sliding window fashion with window sizes of 1 bp (no aggregation) and 50 bp

--- a/bpnet/premade/bpnet9-ginspec.gin
+++ b/bpnet/premade/bpnet9-ginspec.gin
@@ -93,6 +93,7 @@ bpnet_data.tasks = %tasks
 bpnet_data.exclude_chr = %exclude_chr
 bpnet_data.augment_interval = %augment_interval
 bpnet_data.interval_augmentation_shift = 200
+bpnet_data.intervals_format = 'bed'
 
 # transform the bias track by aggregating it in a
 # sliding window fashion with window sizes of 1 bp (no aggregation) and 50 bp

--- a/bpnet/premade/bpnet9-pyspec.gin
+++ b/bpnet/premade/bpnet9-pyspec.gin
@@ -63,6 +63,7 @@ bpnet_data.tasks = %tasks
 bpnet_data.exclude_chr = %exclude_chr
 bpnet_data.augment_interval = %augment_interval
 bpnet_data.interval_augmentation_shift = 200
+bpnet_data.intervals_format = 'bed'
 
 # transform the bias track by aggregating it in a
 # sliding window fashion with window sizes of 1 bp (no aggregation) and 50 bp

--- a/bpnet/seqmodel.py
+++ b/bpnet/seqmodel.py
@@ -331,7 +331,9 @@ class SeqModel:
     def save(self, file_path):
         """Save model to a file
         """
-        from bpnet.utils import write_pkl
+        from bpnet.utils import write_pkl, SerializableLock
+        # fix the serialization of _OPERATIVE_CONFIG_LOCK
+        gin.config._OPERATIVE_CONFIG_LOCK = SerializableLock()
         write_pkl(self, file_path)
 
     @classmethod

--- a/bpnet/utils.py
+++ b/bpnet/utils.py
@@ -392,6 +392,37 @@ class SerializableLock(object):
     level.
 
     The creation of locks is itself not threadsafe.
+
+    This class was taken from dask.utils.py
+
+    ﻿Copyright (c) 2014-2018, Anaconda, Inc. and contributors
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    Neither the name of Anaconda nor the names of any contributors may be used to
+    endorse or promote products derived from this software without specific prior
+    written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+    THE POSSIBILITY OF SUCH DAMAGE.
     """
 
     def __init__(self, token=None):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "deepexplain",
 
     # ml
-    "gin-config",
+    "gin-config==0.2.0",
     "keras==2.2.4",
     "scikit-learn",
     # "tensorflow",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
 
     # ml
     "gin-config",
-    "keras>=2.2.4",
+    "keras==2.2.4",
     "scikit-learn",
     # "tensorflow",
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "deepexplain",
 
     # ml
-    "gin-config==0.2.0",
+    "gin-config",
     "keras==2.2.4",
     "scikit-learn",
     # "tensorflow",

--- a/tests/cli/test_train.py
+++ b/tests/cli/test_train.py
@@ -56,6 +56,18 @@ def test_output_files_model_w_bias(trained_model_w_bias):
     m.predict(encodeDNA(["A" * 200]))
 
 
+def test_trained_model_bed6(tmp_path, data_dir, config_gin, dataspec_bed6):
+    K.clear_session()
+    gin.clear_config()
+    bpnet_train(dataspec=str(dataspec_bed6),
+                output_dir=str(tmp_path),
+                premade='bpnet9',
+                config=str(config_gin),
+                override='seq_width=100;train.batch_size=8',
+                num_workers=2
+                )
+
+
 def test_trained_model_override_in_memory(tmp_path, data_dir, config_gin, dataspec_bias):
     K.clear_session()
     gin.clear_config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,14 @@ def dataspec_bias(data_dir):
 
 
 @fixture(scope='session')
+def dataspec_bed6(data_dir):
+    return data_dir / 'dataspec.bed6.yml'
+
+
+@fixture(scope='session')
 def config_gin(data_dir):
     return data_dir / 'config.gin'
+
 
 @fixture(scope='session')
 def modisco_config_gin(data_dir):

--- a/tests/data/dataspec.bed6.yml
+++ b/tests/data/dataspec.bed6.yml
@@ -1,0 +1,7 @@
+fasta_file: tests/data/dummy/dummy.fa
+task_specs:
+  Task1:
+    tracks:
+      - tests/data/dummy/dummy.pos.bw
+      - tests/data/dummy/dummy.neg.bw
+    peaks: tests/data/dummy/peaks.bed6

--- a/tests/data/dummy/peaks.bed6
+++ b/tests/data/dummy/peaks.bed6
@@ -1,0 +1,16 @@
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr1	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+
+chr2	100	300	one	1	+


### PR DESCRIPTION
This adds `invervals_format` argument to `bpnet_data`. It ignores other columns than the first 3 by default. closes https://github.com/kundajelab/bpnet/issues/1

It also fixes the new error with gin-config=0.2.1