### PR TITLE
Revert "Fix: .h5 contrib file now is compatible with ContribFile.get_profile()"

### DIFF
--- a/bpnet/cli/contrib.py
+++ b/bpnet/cli/contrib.py
@@ -370,17 +370,17 @@ class ContribFile:
                              })
 
     def _get_profile_key(self):
-        template = '/hyp_contrib/profile/{t}'
+        template = '/targets/profile/{t}'
         if isinstance(self.data, dict):
             if template.format(t=self.get_tasks()[0]) in self.data:
                 return template
             else:
-                return '/hyp_contrib/{t}/profile/wn'
+                return '/targets/{t}/profile'
         else:
-            if 'profile' in self.data['hyp_contrib']:
+            if 'profile' in self.data['targets']:
                 return template
             else:
-                return '/hyp_contrib/{t}/profile/wn'
+                return '/targets/{t}/profile'
 
     def get_profiles(self, idx=None):
         tmpl = self._get_profile_key()


### PR DESCRIPTION
Reverts kundajelab/bpnet#10. Incorrectly reviewed the .h5 file.