### PR TITLE
Remove pprint from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ requirements = [
     # utils
     "ipython",
     "tqdm",
-    "pprint",
 
     # Remove
     "genomelake",


### PR DESCRIPTION
As discussed in this [SO post](https://stackoverflow.com/questions/63457762/error-could-not-find-a-version-that-satisfies-the-requirement-pprint-from-r-r), `pprint` is a standard library built-in module and therefore can't be listed as a requirement. The speculative reason why this previously worked is because there may have been a package on pypi named 'pprint' that was recently removed.

Should fix #16.