### PR TITLE
Removed multiprocessing during training

### DIFF
--- a/bpnet/cli/train.py
+++ b/bpnet/cli/train.py
@@ -419,7 +419,7 @@ def train(output_dir,
             valid_dataset = NumpyDataset(valid_dataset.load_all(batch_size=batch_size,
                                                                 num_workers=num_workers))
 
-        num_workers = 1  # don't use multi-processing any more
+        num_workers = 0  # don't use multi-processing any more
 
     tr = trainer_cls(model,
                      train_dataset,


### PR DESCRIPTION
_Same pull request as (https://github.com/kundajelab/bpnet/pull/34), because I had deleted my original fork:_

According to the comment, the intention is to stop multiprocessing after loading the data into memory. However, setting num_workers = 1 results in a creation of an extra process later on when using the custom data loader.

Having the extra worker resulted in deadlocks when I worked with larger data.

Corrected by setting num_workers = 0.